### PR TITLE
Removed AutoFixture package

### DIFF
--- a/src/SimpleMvcSitemap.Tests/SimpleMvcSitemap.Tests.csproj
+++ b/src/SimpleMvcSitemap.Tests/SimpleMvcSitemap.Tests.csproj
@@ -45,9 +45,6 @@
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.1.1311.0615\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture">
-      <HintPath>..\packages\AutoFixture.3.16.1\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/SimpleMvcSitemap.Tests/SitemapProviderTests.cs
+++ b/src/SimpleMvcSitemap.Tests/SitemapProviderTests.cs
@@ -32,7 +32,7 @@ namespace SimpleMvcSitemap.Tests
             _expectedResult = new EmptyResult();
         }
 
-        
+
         [Fact]
         public void CreateSitemap_HttpContextIsNull_ThrowsException()
         {
@@ -88,7 +88,7 @@ namespace SimpleMvcSitemap.Tests
         [Fact]
         public void CreateSitemapWithConfiguration_PageSizeIsBiggerThanNodeCount_CreatesSitemap()
         {
-            var sitemapNodes = new FakeDataSource(CreateMany<SampleData>()).WithCount(1);
+            var sitemapNodes = new FakeDataSource(CreateSampleData()).WithCount(1);
             _config.Setup(item => item.Size).Returns(5);
 
             _config.Setup(item => item.CreateNode(It.IsAny<SampleData>())).Returns(new SitemapNode());
@@ -125,7 +125,7 @@ namespace SimpleMvcSitemap.Tests
         [Fact]
         public void CreateSitemapWithConfiguration_AsksForSpecificPage_CreatesSitemap()
         {
-            FakeDataSource datas = new FakeDataSource(CreateMany<SampleData>()).WithCount(5);
+            FakeDataSource datas = new FakeDataSource(CreateSampleData()).WithCount(5);
 
             _config.Setup(item => item.Size).Returns(2);
             _config.Setup(item => item.CurrentPage).Returns(2);
@@ -163,6 +163,10 @@ namespace SimpleMvcSitemap.Tests
             result.Should().Be(_expectedResult);
         }
 
+        private IEnumerable<SampleData> CreateSampleData(int count = 3)
+        {
+            return Enumerable.Range(1, count).Select(i => new SampleData { Title = i.ToString() });
+        }
 
     }
 }

--- a/src/SimpleMvcSitemap.Tests/TestBase.cs
+++ b/src/SimpleMvcSitemap.Tests/TestBase.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using Moq;
-using Ploeh.AutoFixture;
 
 namespace SimpleMvcSitemap.Tests
 {
@@ -12,7 +10,6 @@ namespace SimpleMvcSitemap.Tests
         protected TestBase()
         {
             _mockRepository = new MockRepository(MockBehavior.Strict);
-            FakeDataRepository = new Fixture();
             VerifyAll = true;
         }
 
@@ -21,25 +18,8 @@ namespace SimpleMvcSitemap.Tests
             return _mockRepository.Create<T>();
         }
 
-        protected IFixture FakeDataRepository { get; set; }
 
         protected bool VerifyAll { get; set; }
-
-
-        protected T Create<T>()
-        {
-            return FakeDataRepository.Create<T>();
-        }
-        
-        protected IEnumerable<T> CreateMany<T>()
-        {
-            return FakeDataRepository.CreateMany<T>();
-        }
-
-        protected IEnumerable<T> CreateMany<T>(int count)
-        {
-            return FakeDataRepository.CreateMany<T>(count);
-        }
 
 
         public virtual void Dispose()

--- a/src/SimpleMvcSitemap.Tests/packages.config
+++ b/src/SimpleMvcSitemap.Tests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.16.1" targetFramework="net40" />
   <package id="FluentAssertions" version="2.1.0.0" targetFramework="net40" />
   <package id="JetBrains.Annotations" version="8.0.4.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="3.0.20105.1" targetFramework="net40" />


### PR DESCRIPTION
AutoFixture is not ported to .NET Core yet and it's not used heavily in the tests.