### PR TITLE
Google requires W3C Datetime

### DIFF
--- a/src/SimpleMvcSitemap/SitemapIndexNode.cs
+++ b/src/SimpleMvcSitemap/SitemapIndexNode.cs
@@ -59,7 +59,7 @@ namespace SimpleMvcSitemap
         ///  i.e. a crawler may only retrieve Sitemaps that were modified since a certain date.
         /// This incremental Sitemap fetching mechanism allows for the rapid discovery of new URLs on very large sites.
         /// </summary>
-        [XmlElement("lastmod", Order = 2)]
+        [XmlIgnore]
         public DateTime? LastModificationDate { get; set; }
 
 

--- a/src/SimpleMvcSitemap/SitemapIndexNode.cs
+++ b/src/SimpleMvcSitemap/SitemapIndexNode.cs
@@ -30,7 +30,28 @@ namespace SimpleMvcSitemap
         [XmlElement("loc", Order = 1), Url]
         public string Url { get; set; }
 
-        
+        /// <summary>
+        /// Identifies the time that the corresponding Sitemap file was modified.
+        /// It does not correspond to the time that any of the pages listed in that Sitemap were changed.
+        /// By providing the last modification timestamp, you enable search engine crawlers to retrieve only a subset of the Sitemaps in the index
+        ///  i.e. a crawler may only retrieve Sitemaps that were modified since a certain date.
+        /// This incremental Sitemap fetching mechanism allows for the rapid discovery of new URLs on very large sites.
+        /// </summary>
+        [XmlElement("lastmod", Order = 2)]
+        public string GetLastModificationDate
+        {
+            get
+            {
+                if (LastModificationDate != null)
+                {
+                    return ((DateTime)LastModificationDate).ToString("yyyy-MM-ddTHH:mm:ss.fffffffzzz");
+                }
+                else
+                    return null;
+            }
+            set { this.LastModificationDate = DateTime.Parse(value); }
+        }
+
         /// <summary>
         /// Identifies the time that the corresponding Sitemap file was modified.
         /// It does not correspond to the time that any of the pages listed in that Sitemap were changed.

--- a/src/SimpleMvcSitemap/SitemapNode.cs
+++ b/src/SimpleMvcSitemap/SitemapNode.cs
@@ -35,11 +35,28 @@ namespace SimpleMvcSitemap
         [XmlElement("loc", Order = 1), Url]
         public string Url { get; set; }
 
-
         /// <summary>
         /// Shows the date the URL was last modified, value is optional.
         /// </summary>
         [XmlElement("lastmod", Order = 2)]
+        public string GetLastModificationDate
+        {
+            get
+            {
+                if (LastModificationDate != null)
+                {
+                    return ((DateTime)LastModificationDate).ToString("yyyy-MM-ddTHH:mm:ss.fffffffzzz");
+                }
+                else
+                    return null;
+            }
+            set { this.LastModificationDate = DateTime.Parse(value); }
+        }
+
+        /// <summary>
+        /// Stores the date the URL was last modified, value is optional.
+        /// </summary>
+        [XmlIgnore]
         public DateTime? LastModificationDate { get; set; }
 
 


### PR DESCRIPTION
Google Search Console requires W3C Datetime but XML had other type of datetime string. 

https://support.google.com/webmasters/answer/7451001?hl=en#zippy=%2Ccomplete-error-list

![image](https://user-images.githubusercontent.com/6968747/105816324-35c17900-5fc5-11eb-848b-9920e3becf81.png)

I changed models to create this datetime string.