### PR TITLE
Automatic Sitemap.xml creation and dependency fixup and multi-targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ public class SitemapController : Controller
 
 As of version 4.1.2 you can now auto-generate sitemap.xml (and optionally a robot.txt) file by having the system auto discover all controllers and actions (and/or razor pages).
 
-This will inject a middleware that will listen for HTTP request to \sitemap.xml, and optionally \robot.txt. When that occurs it will auto-respond to the request by outputing an automatically generated sitemap.xml or robots.txt
+This will inject a middleware that will listen for HTTP request to \sitemap.xml, and optionally \robots.txt. When that occurs it will auto-respond to the request by outputing an automatically generated sitemap.xml or robots.txt
 
 Here are some examples of what you would add to your startup code:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ SimpleMvcSitemap lets you create [sitemap files](http://www.sitemaps.org/protoco
  - [XSL Style Sheets](#style-sheets)
  - [Custom Base URL](#base-url)  
  - [Unit Testing and Dependency Injection](#di)
+ - [Automatic sitemap.xml generation](#di)
  - [License](#license)
 
 
@@ -227,6 +228,27 @@ public class SitemapController : Controller
 	
     //action methods
 }
+```
+## <a id="autogenerate">Sitemap Automatic Creation</a>
+
+As of version 4.1.2 you can now auto-generate sitemap.xml (and optionally a robot.txt) file by having the system auto discover all controllers and actions (and/or razor pages).
+
+This will inject a middleware that will listen for HTTP request to \sitemap.xml, and optionally \robot.txt. When that occurs it will auto-respond to the request by outputing an automatically generated sitemap.xml or robots.txt
+
+Here are some examples of what you would add to your startup code:
+
+### Example of Sitemap generation
+```csharp
+app.UseSitemap(new SitemapGeneratorOptions() { DefaultChangeFrequency = SimpleMvcSitemap.ChangeFrequency.Daily, DefaultPriority = .9M, LastModifiedDate = File.GetCreationTime(Assembly.GetExecutingAssembly().Location) });
+```
+### Example of Sitemap Index generation
+```csharp
+app.UseSitemap(new SitemapGeneratorOptions() {  DefaultSiteMapType = SiteMapType.SitemapIndex });
+```
+
+### Example of Sitemap Index generation with optional robots.txt creation as well
+```csharp
+app.UseSitemap(new SitemapGeneratorOptions() {  EnableRobotsTxtGeneration = true });
 ```
 
 ## <a id="license">License</a>

--- a/src/SimpleMvcSitemap/Middleware/MiddlewareExtensions.cs
+++ b/src/SimpleMvcSitemap/Middleware/MiddlewareExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Builder;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SimpleMvcSitemap.Middleware
+{
+    /// <summary>
+    /// Sitemap Auto generator middleware
+    /// </summary>
+    public static class MiddlewareExtensions
+    {
+        /// <summary>
+        /// Activates the automatic sitemap generator. Usage: app.UseSitemap() within your application startup.
+        /// Uses default SitemapGeneratorOptions
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseSitemap(this IApplicationBuilder builder) => UseMiddlewareExtensions.UseMiddleware<SitemapMiddleware>(builder);
+
+        /// <summary>
+        /// Activates the automatic sitemap generator. Usage: app.UseSitemap() within your application startup.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="sitemapOptions">Sitemap Generator options</param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseSitemap(this IApplicationBuilder builder, SitemapGeneratorOptions sitemapOptions)
+        {
+            return UseMiddlewareExtensions.UseMiddleware<SitemapMiddleware>(builder, sitemapOptions);
+        }
+    }
+}

--- a/src/SimpleMvcSitemap/Middleware/SitemapExcludeAttribute.cs
+++ b/src/SimpleMvcSitemap/Middleware/SitemapExcludeAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SimpleMvcSitemap.Middleware
+{
+    /// <summary>
+    /// Excludes a controller or action from being output in a sitemap.xml file when using the automatic sitemap generator
+    /// </summary>
+    public class SitemapExcludeAttribute : Attribute
+    {
+    }
+}

--- a/src/SimpleMvcSitemap/Middleware/SitemapGeneratorBaseUrl.cs
+++ b/src/SimpleMvcSitemap/Middleware/SitemapGeneratorBaseUrl.cs
@@ -1,0 +1,12 @@
+﻿using SimpleMvcSitemap.Routing;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SimpleMvcSitemap.Middleware
+{
+    internal class SitemapGeneratorBaseUrl : IBaseUrlProvider
+    {
+        public Uri BaseUrl { get; set; }
+    }
+}

--- a/src/SimpleMvcSitemap/Middleware/SitemapGeneratorOptions.cs
+++ b/src/SimpleMvcSitemap/Middleware/SitemapGeneratorOptions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SimpleMvcSitemap.Middleware
+{
+    /// <summary>
+    /// Sitemap Automatic Generator Options
+    /// </summary>
+    public class SitemapGeneratorOptions
+    {
+        /// <summary>
+        /// Default Sitemap Type (Defaults to SitemapIndex)
+        /// </summary>
+        public SiteMapType DefaultSiteMapType { get; set; } = SiteMapType.SitemapIndex;
+        /// <summary>
+        /// Base Url, if null defaults to the requests Url.
+        /// </summary>
+        public string BaseUrl { get; set; }
+        /// <summary>
+        /// Enable automatic robots.txt generation (Defaults to true)
+        /// </summary>
+        public bool EnableRobotsTxtGeneration { get; set; } = true;
+        /// <summary>
+        /// Default change frequency
+        /// </summary>
+        public ChangeFrequency? DefaultChangeFrequency { get; set; }
+        /// <summary>
+        /// Default priority
+        /// </summary>
+        public decimal? DefaultPriority { get; set; }
+        /// <summary>
+        /// Detect last modification date from the file system (Defaults to false)
+        /// </summary>
+        public bool DetectLastModificationDate { get; set; } = false;
+    }
+
+    /// <summary>
+    /// Sitemap Type
+    /// </summary>
+    public enum SiteMapType
+    {
+        /// <summary>
+        /// Creates Sitemap files
+        /// http://www.sitemaps.org/protocol.html
+        /// </summary>
+        Sitemap,
+        /// <summary>
+        /// Creates sitemap index files
+        /// http://www.sitemaps.org/protocol.html#index
+        /// </summary>
+        SitemapIndex
+    }
+}

--- a/src/SimpleMvcSitemap/Middleware/SitemapGeneratorOptions.cs
+++ b/src/SimpleMvcSitemap/Middleware/SitemapGeneratorOptions.cs
@@ -10,7 +10,7 @@ namespace SimpleMvcSitemap.Middleware
     public class SitemapGeneratorOptions
     {
         /// <summary>
-        /// Default Sitemap Type (Defaults to SitemapIndex)
+        /// Default Sitemap Type (Defaults to Sitemap)
         /// </summary>
         public SiteMapType DefaultSiteMapType { get; set; } = SiteMapType.Sitemap;
         /// <summary>
@@ -18,9 +18,9 @@ namespace SimpleMvcSitemap.Middleware
         /// </summary>
         public string BaseUrl { get; set; }
         /// <summary>
-        /// Enable automatic robots.txt generation (Defaults to true)
+        /// Enable automatic robots.txt generation (Defaults to false)
         /// </summary>
-        public bool EnableRobotsTxtGeneration { get; set; } = true;
+        public bool EnableRobotsTxtGeneration { get; set; } = false;
         /// <summary>
         /// Default change frequency
         /// </summary>

--- a/src/SimpleMvcSitemap/Middleware/SitemapGeneratorOptions.cs
+++ b/src/SimpleMvcSitemap/Middleware/SitemapGeneratorOptions.cs
@@ -30,9 +30,10 @@ namespace SimpleMvcSitemap.Middleware
         /// </summary>
         public decimal? DefaultPriority { get; set; }
         /// <summary>
-        /// Detect last modification date from the file system (Defaults to false)
+        /// Sets the last modification date on pages. Typically this would be the applications compile date as the views don't change once
+        /// they are compiled into ASP .NET Core web app.
         /// </summary>
-        public bool DetectLastModificationDate { get; set; } = false;
+        public DateTime? LastModifiedDate { get; set; }
     }
 
     /// <summary>

--- a/src/SimpleMvcSitemap/Middleware/SitemapGeneratorOptions.cs
+++ b/src/SimpleMvcSitemap/Middleware/SitemapGeneratorOptions.cs
@@ -12,7 +12,7 @@ namespace SimpleMvcSitemap.Middleware
         /// <summary>
         /// Default Sitemap Type (Defaults to SitemapIndex)
         /// </summary>
-        public SiteMapType DefaultSiteMapType { get; set; } = SiteMapType.SitemapIndex;
+        public SiteMapType DefaultSiteMapType { get; set; } = SiteMapType.Sitemap;
         /// <summary>
         /// Base Url, if null defaults to the requests Url.
         /// </summary>

--- a/src/SimpleMvcSitemap/Middleware/SitemapMiddleware.cs
+++ b/src/SimpleMvcSitemap/Middleware/SitemapMiddleware.cs
@@ -109,6 +109,8 @@ namespace SimpleMvcSitemap.Middleware
                 node.Priority = _options.DefaultPriority;
             if (_options.DefaultChangeFrequency != null)
                 node.ChangeFrequency = _options.DefaultChangeFrequency;
+            if (_options.LastModifiedDate != null)
+                node.LastModificationDate = _options.LastModifiedDate;
             return node;
         }
 

--- a/src/SimpleMvcSitemap/Middleware/SitemapMiddleware.cs
+++ b/src/SimpleMvcSitemap/Middleware/SitemapMiddleware.cs
@@ -1,0 +1,240 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Routing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace SimpleMvcSitemap.Middleware
+{
+    internal class SitemapMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IActionDescriptorCollectionProvider _collectionProvider;
+        private readonly SitemapGeneratorOptions _options;
+        private readonly LinkGenerator _linkGenerator;
+        private readonly SitemapProvider _sitemapProvider;
+        private readonly List<Type> _excludedVerbs = new List<Type>()
+        {
+          typeof (HttpPostAttribute),
+          typeof (HttpDeleteAttribute),
+          typeof (HttpPutAttribute),
+          typeof (HttpHeadAttribute),
+          typeof (HttpOptionsAttribute),
+          typeof (HttpPatchAttribute)
+        };
+
+        public SitemapMiddleware(RequestDelegate next, IActionDescriptorCollectionProvider collectionProvider, LinkGenerator linkGenerator)
+        {
+            _next = next;
+            _collectionProvider = collectionProvider ?? throw new ArgumentNullException(nameof(collectionProvider));
+            _options = new SitemapGeneratorOptions(); //Take all the defaults
+            _linkGenerator = linkGenerator ?? throw new ArgumentNullException(nameof(linkGenerator));
+            _sitemapProvider = new SitemapProvider();
+        }
+
+        public SitemapMiddleware(RequestDelegate next, IActionDescriptorCollectionProvider collectionProvider, LinkGenerator linkGenerator, SitemapGeneratorOptions options)
+          : this(next, collectionProvider, linkGenerator)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            if (_options.BaseUrl != null)
+                _sitemapProvider = new SitemapProvider(new SitemapGeneratorBaseUrl() { BaseUrl = new Uri(_options.BaseUrl) });
+            else
+                _sitemapProvider = new SitemapProvider();
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if (SitemapMiddleware.IsSiteMapRequested(context))
+                await WriteSitemapAsync(context);
+            else if (_options != null && _options.EnableRobotsTxtGeneration && SitemapMiddleware.IsRobotsRequested(context))
+                await WriteRobotsAsync(context);
+            else
+                await _next.Invoke(context);
+        }
+
+        private Task WriteSitemapAsync(HttpContext context)
+        {
+            if (_options.DefaultSiteMapType == SiteMapType.Sitemap)
+            {
+                var model = GetSitemapModel(context, _collectionProvider.ActionDescriptors.Items, GetSiteBaseUrl(context.Request));
+                var sitemapData = new Serialization.XmlSerializer().Serialize(model);
+                return SitemapMiddleware.WriteStringContentAsync(context, sitemapData, "application/xml");
+            }
+            else //SitemapType.SitemapIndex
+            {
+                var model = GetSitemapIndexModel(context, _collectionProvider.ActionDescriptors.Items, GetSiteBaseUrl(context.Request));
+                var sitemapData = new Serialization.XmlSerializer().Serialize(model);
+                return SitemapMiddleware.WriteStringContentAsync(context, sitemapData, "application/xml");
+            }
+        }
+
+        private SitemapModel GetSitemapModel(HttpContext context, IEnumerable<ActionDescriptor> routes, string siteBase)
+        {
+            List<SitemapNode> validUrls = new List<SitemapNode>();
+            foreach (ActionDescriptor route in routes)
+            {
+                if (route is PageActionDescriptor && route?.AttributeRouteInfo != null && IsIncludedRoute(route)) //Razor page routing
+                {
+                    var pageRoute = (PageActionDescriptor)route;
+                    string url = siteBase + "/" + route.AttributeRouteInfo.Template;
+                    var sitemapNode = GetSiteMapNode(url);
+                    if (url != null && !validUrls.Contains(sitemapNode))
+                        validUrls.Add(sitemapNode);
+                }
+                else if (route is ControllerActionDescriptor && route != null && IsIncludedRoute(route)) //MVC/Controller page routing, supports routing that use attributes and without attributes, https://joonasw.net/view/discovering-actions-and-razor-pages
+                {
+                    var controllerRoute = (ControllerActionDescriptor)route;
+                    var url = siteBase + _linkGenerator.GetPathByAction(controllerRoute.ActionName, controllerRoute.ControllerName, controllerRoute.RouteValues); //Link generator supports attribute and standard routing configuration
+                    var sitemapNode = GetSiteMapNode(url);
+                    if (url != null && !validUrls.Contains(sitemapNode))
+                        validUrls.Add(sitemapNode);
+                }
+            }
+            return new SitemapModel(validUrls);
+        }
+        private SitemapNode GetSiteMapNode(string url)
+        {
+            var node = new SitemapNode(url);
+            if (_options.DefaultPriority != null)
+                node.Priority = _options.DefaultPriority;
+            if (_options.DefaultChangeFrequency != null)
+                node.ChangeFrequency = _options.DefaultChangeFrequency;
+            return node;
+        }
+
+        private SitemapIndexModel GetSitemapIndexModel(HttpContext context, IEnumerable<ActionDescriptor> routes, string siteBase)
+        {
+            List<SitemapIndexNode> validUrls = new List<SitemapIndexNode>();
+            foreach (ActionDescriptor route in routes)
+            {
+                if (route is PageActionDescriptor && route?.AttributeRouteInfo != null && IsIncludedRoute(route)) //Razor page routing
+                {
+                    var pageRoute = (PageActionDescriptor)route;
+                    string url = siteBase + "/" + route.AttributeRouteInfo.Template;
+                    var sitemapNode = new SitemapIndexNode(url);
+                    if (url != null && !validUrls.Contains(sitemapNode))
+                        validUrls.Add(sitemapNode);
+                }
+                else if (route is ControllerActionDescriptor && route != null && IsIncludedRoute(route)) //MVC/Controller page routing, supports routing that use attributes and without attributes, https://joonasw.net/view/discovering-actions-and-razor-pages
+                {
+                    var controllerRoute = (ControllerActionDescriptor)route;
+                    var url = siteBase + _linkGenerator.GetPathByAction(controllerRoute.ActionName, controllerRoute.ControllerName, controllerRoute.RouteValues); //Link generator supports attribute and standard routing configuration
+                    var sitemapNode = new SitemapIndexNode(url);
+                    if (url != null && !validUrls.Contains(sitemapNode))
+                        validUrls.Add(sitemapNode);
+                }
+            }
+            return new SitemapIndexModel(validUrls);
+        }
+
+        //private IEnumerable<string> GetValidUrls(HttpContext context, IEnumerable<ActionDescriptor> routes, string siteBase)
+        //{
+        //    List<string> validUrls = new List<string>();
+        //    foreach (ActionDescriptor route in routes)
+        //    {
+        //        if (route is PageActionDescriptor && route?.AttributeRouteInfo != null && IsIncludedRoute(route)) //Razor page routing
+        //        {
+        //            var pageRoute = (PageActionDescriptor)route;
+        //            string url = siteBase + "/" + route.AttributeRouteInfo.Template;
+        //            if (url != null && !validUrls.Contains(url))
+        //                validUrls.Add(url);
+        //        }
+        //        else if (route is ControllerActionDescriptor && route != null && IsIncludedRoute(route)) //MVC/Controller page routing, supports routing use attributes and without attributes, https://joonasw.net/view/discovering-actions-and-razor-pages
+        //        {
+        //            var controllerRoute = (ControllerActionDescriptor)route;
+        //            var url = siteBase + _linkGenerator.GetPathByAction(controllerRoute.ActionName, controllerRoute.ControllerName, controllerRoute.RouteValues); //Link generator supports attribute and standard routing configuration
+        //            if (url != null && !validUrls.Contains(url))
+        //                validUrls.Add(url);
+        //        }
+        //    }
+        //    return validUrls;
+        //}
+
+        private bool IsIncludedRoute(ActionDescriptor route)
+        {
+            if (route is ControllerActionDescriptor actionDescriptor)
+            {
+                MethodInfo methodInfo = actionDescriptor.MethodInfo;
+                if (methodInfo != null && (SitemapMiddleware.HasExclusionAttribute(((MemberInfo)methodInfo).CustomAttributes) || IsExcludedVerb(((MemberInfo)methodInfo).CustomAttributes)))
+                    return false;
+                TypeInfo controllerTypeInfo = actionDescriptor.ControllerTypeInfo;
+                if ((Type)controllerTypeInfo != null && SitemapMiddleware.HasExclusionAttribute(((MemberInfo)controllerTypeInfo).CustomAttributes))
+                    return false;
+            }
+            return true;
+        }
+
+        private static string BuildSitemapXml(IEnumerable<string> urls)
+        {
+            StringBuilder stringBuilder = new StringBuilder("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\r\n");
+            foreach (string url in urls)
+                stringBuilder.Append("<url>\r\n<loc>" + url + "</loc>\r\n</url>\r\n");
+            stringBuilder.Append("</urlset>");
+            return stringBuilder.ToString();
+        }
+
+        private static bool HasExclusionAttribute(IEnumerable<CustomAttributeData> attributes) => attributes != null && attributes.Any<CustomAttributeData>((Func<CustomAttributeData, bool>)(x => x.AttributeType == typeof(SitemapExcludeAttribute)));
+
+        private bool IsExcludedVerb(IEnumerable<CustomAttributeData> attributes) => attributes != null && _excludedVerbs.Any<Type>((Func<Type, bool>)(excludedVerb => attributes.Any<CustomAttributeData>((Func<CustomAttributeData, bool>)(x => x.AttributeType == excludedVerb))));
+
+        private Task WriteRobotsAsync(HttpContext context)
+        {
+            string content = "User-agent: *\r\nAllow: /\r\nSitemap: " + GetSitemapUrl(context.Request);
+            return SitemapMiddleware.WriteStringContentAsync(context, content, "text/plain");
+        }
+
+        private string GetSitemapUrl(HttpRequest contextRequest) => GetSiteBaseUrl(contextRequest) + "/sitemap.xml";
+
+        private static bool IsSiteMapRequested(HttpContext context)
+        {
+            PathString path = context.Request.Path;
+            if (path == null)
+                return false;
+            if (path.Value != null)
+                return path.Value.Equals("/sitemap.xml", StringComparison.OrdinalIgnoreCase);
+            return false;
+        }
+
+        private static bool IsRobotsRequested(HttpContext context)
+        {
+            PathString path = context.Request.Path;
+            if (path == null)
+                return false;
+            if (path.Value != null)
+                return path.Value.Equals("/robots.txt", StringComparison.OrdinalIgnoreCase);
+            return false;
+        }
+
+        private static async Task WriteStringContentAsync(HttpContext context, string content, string contentType)
+        {
+            Stream body = context.Response.Body;
+            context.Response.StatusCode = 200;
+            context.Response.ContentType = contentType;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                byte[] bytes = Encoding.UTF8.GetBytes(content);
+                memoryStream.Write(bytes, 0, bytes.Length);
+                memoryStream.Seek(0, SeekOrigin.Begin);
+                await memoryStream.CopyToAsync(body, bytes.Length);
+            }
+        }
+
+        private string GetSiteBaseUrl(HttpRequest request)
+        {
+            string str = request.Scheme;
+            if (_options.BaseUrl != null)
+                return _options.BaseUrl.ToString();
+            return string.Format("{0}://{1}{2}", str, request.Host, request.PathBase);
+        }
+    }
+}

--- a/src/SimpleMvcSitemap/Middleware/SitemapMiddleware.cs
+++ b/src/SimpleMvcSitemap/Middleware/SitemapMiddleware.cs
@@ -139,29 +139,6 @@ namespace SimpleMvcSitemap.Middleware
             return new SitemapIndexModel(validUrls);
         }
 
-        //private IEnumerable<string> GetValidUrls(HttpContext context, IEnumerable<ActionDescriptor> routes, string siteBase)
-        //{
-        //    List<string> validUrls = new List<string>();
-        //    foreach (ActionDescriptor route in routes)
-        //    {
-        //        if (route is PageActionDescriptor && route?.AttributeRouteInfo != null && IsIncludedRoute(route)) //Razor page routing
-        //        {
-        //            var pageRoute = (PageActionDescriptor)route;
-        //            string url = siteBase + "/" + route.AttributeRouteInfo.Template;
-        //            if (url != null && !validUrls.Contains(url))
-        //                validUrls.Add(url);
-        //        }
-        //        else if (route is ControllerActionDescriptor && route != null && IsIncludedRoute(route)) //MVC/Controller page routing, supports routing use attributes and without attributes, https://joonasw.net/view/discovering-actions-and-razor-pages
-        //        {
-        //            var controllerRoute = (ControllerActionDescriptor)route;
-        //            var url = siteBase + _linkGenerator.GetPathByAction(controllerRoute.ActionName, controllerRoute.ControllerName, controllerRoute.RouteValues); //Link generator supports attribute and standard routing configuration
-        //            if (url != null && !validUrls.Contains(url))
-        //                validUrls.Add(url);
-        //        }
-        //    }
-        //    return validUrls;
-        //}
-
         private bool IsIncludedRoute(ActionDescriptor route)
         {
             if (route is ControllerActionDescriptor actionDescriptor)

--- a/src/SimpleMvcSitemap/SimpleMvcSitemap.csproj
+++ b/src/SimpleMvcSitemap/SimpleMvcSitemap.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.0.11" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="System.Linq.Queryable" Version="4.0.1" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SimpleMvcSitemap/SimpleMvcSitemap.csproj
+++ b/src/SimpleMvcSitemap/SimpleMvcSitemap.csproj
@@ -1,20 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Version>4.0.1</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <IncludeSymbols>true</IncludeSymbols>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Authors>Ufuk Hacıoğulları</Authors>
-    <Description>A minimalist library for creating sitemap files inside ASP.NET Core applications.</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/uhaciogullari/SimpleMvcSitemap</PackageProjectUrl>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Version>4.1.1</Version>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <IncludeSymbols>true</IncludeSymbols>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageTags>sitemap;robots.txt;sitemap.xml;aspnet;aspnetcore</PackageTags>
+        <Authors>Ufuk Hacıoğulları</Authors>
+        <Description>A minimalist library for creating sitemap files inside ASP.NET Core applications.</Description>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/uhaciogullari/SimpleMvcSitemap</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/uhaciogullari/SimpleMvcSitemap</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+        <RootNamespace>SimpleMvcSitemap</RootNamespace>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
-  </ItemGroup>
-
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
 </Project>

--- a/src/SimpleMvcSitemap/SimpleMvcSitemap.csproj
+++ b/src/SimpleMvcSitemap/SimpleMvcSitemap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>4.1.1</Version>
+        <Version>4.1.2</Version>
         <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <IncludeSymbols>true</IncludeSymbols>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/SimpleMvcSitemap/SimpleMvcSitemap.csproj
+++ b/src/SimpleMvcSitemap/SimpleMvcSitemap.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>4.0.1</Version>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeSymbols>true</IncludeSymbols>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Ufuk Hacıoğulları</Authors>
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.0.1" />
   </ItemGroup>
 

--- a/test/SimpleMvcSitemap.Tests/SimpleMvcSitemap.Tests.csproj
+++ b/test/SimpleMvcSitemap.Tests/SimpleMvcSitemap.Tests.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
 
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
+
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/SimpleMvcSitemap.Tests/SimpleMvcSitemap.Tests.csproj
+++ b/test/SimpleMvcSitemap.Tests/SimpleMvcSitemap.Tests.csproj
@@ -7,12 +7,18 @@
 
   <ItemGroup>
 
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <ProjectReference Include="..\..\src\SimpleMvcSitemap\SimpleMvcSitemap.csproj" />
 
     <None Update="xunit.runner.json;Samples\*.xml">

--- a/test/SimpleMvcSitemap.Tests/XmlAssertionExtensions.cs
+++ b/test/SimpleMvcSitemap.Tests/XmlAssertionExtensions.cs
@@ -2,7 +2,7 @@
 using FluentAssertions.Primitives;
 using System.Xml.Linq;
 using System.IO;
-using Microsoft.Extensions.PlatformAbstractions;
+using Microsoft.DotNet.PlatformAbstractions;
 
 namespace SimpleMvcSitemap.Tests
 {
@@ -10,7 +10,7 @@ namespace SimpleMvcSitemap.Tests
     {
         public static void BeXmlEquivalent(this StringAssertions assertions, string filename)
         {
-            var fullPath = Path.Combine(new ApplicationEnvironment().ApplicationBasePath, "Samples", filename);
+            var fullPath = Path.Combine(ApplicationEnvironment.ApplicationBasePath, "Samples", filename);
             XDocument doc1 = XDocument.Parse(File.ReadAllText(fullPath));
             XDocument doc2 = XDocument.Parse(assertions.Subject);
 


### PR DESCRIPTION
- Implements #48 
- Adds automatic robots.txt creation as well
- Fixes the dependencies (current library uses old .net core references that are marked by Microsoft with critical vulnerabilities)
- Removes unnecessary dependencies
- Also addresses what was mentioned in #44 due to it's built in multi-targeting nuget updates

Nice clean dependency list now:
![image](https://user-images.githubusercontent.com/6610039/145723439-538e24bd-893f-458d-9b97-a7c300e8345e.png)
